### PR TITLE
Removed erroneous 4-bit shift

### DIFF
--- a/adafruit_lsm303.py
+++ b/adafruit_lsm303.py
@@ -177,8 +177,7 @@ class LSM303(object):
         """
         self._read_bytes(self._mag_device, _REG_MAG_OUT_X_H_M, 6, self._BUFFER)
         raw_values = struct.unpack_from('>hhh', self._BUFFER[0:6])
-        values = tuple([n >> 4 for n in raw_values])
-        return (values[0], values[2], values[1])
+        return (raw_values[0], raw_values[2], raw_values[1])
 
     @property
     def magnetic(self):


### PR DESCRIPTION
Values are already 16-bits signed, with 12-bit data, so it can be returned as is. The datasheet isn't terribly clear here, but testing leads me to the conclusion that the code in this PR is the correct solution. The math makes sense for 12-bit values in a 16-bit signed wrapper, though not full 16-bit data. The DS states at +/-2g on the accel 1 lsb = 1mg, so at 12-bits we get 4096mg or +/-2g. The values seem the be returned already formed as 16-bit signed integers, though, so the right-shift is incorrect.